### PR TITLE
Better Path Handling & Prevent Duplicate Symlinks

### DIFF
--- a/module/whiteout_gen.sh
+++ b/module/whiteout_gen.sh
@@ -65,8 +65,19 @@ vendor"
 # this assumes magic mount
 for dir in $targets; do 
 	if [ -d /$dir ] && [ ! -L /$dir ] && [ -d "$MODULE_UPDATES_DIR/system/$dir" ]; then
-		echo "[+] creating symlink for /$dir"
-		ln -sf "./system/$dir" "$MODULE_UPDATES_DIR/$dir"
+		if [ -L "$MODULE_UPDATES_DIR/$dir" ]; then
+			# Check if the symlink points to the correct location
+			if [ $(readlink -f $MODULE_UPDATES_DIR/$dir) != $(realpath $MODULE_UPDATES_DIR/system/$dir) ]; then
+				echo "[!] Incorrect symlink for /$dir, fixing..."
+				rm -f $MODULE_UPDATES_DIR/$dir
+				ln -sf ./system/$dir $MODULE_UPDATES_DIR/$dir
+			else
+				echo "[+] Symlink for /$dir is correct, skipping..."
+			fi
+		else
+			echo "[+] Creating symlink for /$dir"
+			ln -sf ./system/$dir $MODULE_UPDATES_DIR/$dir
+		fi
 	fi
 done
 

--- a/module/whiteout_gen.sh
+++ b/module/whiteout_gen.sh
@@ -42,7 +42,13 @@ whiteout_create() {
 }
 
 for line in $( sed '/#/d' "$TEXTFILE" ); do
-	echo "$line" | grep -q "^/system/" && whiteout_create "$line" > /dev/null 2>&1
+	if echo "$line" | grep -Eq "^/(product|vendor|odm|system_ext)/" && ! echo "$line" | grep -q "^/system/"; then
+		line="/system$line"
+	elif ! echo "$line" | grep -q "^/system/"; then
+		echo "[!] Invalid input $line. Skipping..."
+		continue
+	fi
+	whiteout_create "$line" > /dev/null 2>&1
 	ls "$MODULE_UPDATES_DIR$line" 2>/dev/null
 done
 


### PR DESCRIPTION
- Prepend /system when needed
- Prevent duplicate symlinks in MODULE_UPDATES_DIR when executing the script twice by checking if they exist and point to the correct target before modifying.
