### PR TITLE
scripts/customize: revert installation block on vermeer

### DIFF
--- a/module/customize.sh
+++ b/module/customize.sh
@@ -25,11 +25,6 @@ else
 	sleep 2
 fi
 
-# theres reports that it bootloops on certain devices
-if getprop ro.product.name | grep -q 'vermeer' ; then
-	abort "[!] Installation aborted as device \"vermeer\" is not supported"
-fi
-
 if [ ! "$APATCH" = true ] && [ ! "$KSU" = true ] && [ -f "/data/adb/magisk/magisk" ] &&
 	[ "$(/data/adb/magisk/magisk -V)" -ge 30000 ]; then
 	echo "[!] oxidized versions of magisk has issues related to mounting!"


### PR DESCRIPTION
Since we use bootloop protection, I don't think it is necessary to have...

This commit partially reverts 949f66b